### PR TITLE
Criação do controlador de definição

### DIFF
--- a/src/main/java/com/mycompany/controller/ControllerDefinicao.java
+++ b/src/main/java/com/mycompany/controller/ControllerDefinicao.java
@@ -1,0 +1,33 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.mycompany.controller;
+
+import com.mycompany.model.Definicao;
+import com.mycompany.model.Experimento;
+
+/**
+ *
+ * @author paulo
+ */
+
+
+public class ControllerDefinicao {
+    
+    public static boolean saveDefinicao(Experimento experimento, String objEstudo ,String objetivo ,String perspectiva ,
+            String focoQualidade ,String contexto , boolean editavel){
+        
+        if(experimento != null && objEstudo != null && objetivo != null && perspectiva != null 
+        && focoQualidade != null && contexto != null){
+            
+            Definicao novaDefinicao = new Definicao(experimento, objEstudo, objetivo, perspectiva, 
+                                                    focoQualidade, contexto, editavel, false);
+            return novaDefinicao.saveOnDatabase(); 
+        }
+        
+        return false;
+    }
+    
+}


### PR DESCRIPTION
Foi assumido que o id do experimentador virá do servlet e que o estado de concluido é sempre false quando criado uma nova definição